### PR TITLE
Expand Empire OS schema and agent mapping

### DIFF
--- a/docs/empire_os/implementation_briefing.md
+++ b/docs/empire_os/implementation_briefing.md
@@ -1,0 +1,1009 @@
+# Empire OS — Codex Implementation Briefing
+
+## Quick summary (what to build)
+
+A single, modular web application (single-pane-of-glass) that:
+
+* logs **every atomic event** (append-only event stream),
+* stores canonical, strongly-relational data model (no free-text canonical fields),
+* stores raw blobs in object store and semantic vectors in a vector DB,
+* runs **agents** that find/organize/integrate/predict/operate on logs (FOIP),
+* supports deterministic automations (n8n/webhooks) and human approvals,
+* provides an advanced UI with a command palette, replay mode, simulation canvas, and entity pages,
+* supports enterprise-grade security (AD/RBAC, MFA/YubiKey, encryption, Merkle chaining for immutability),
+* keeps everything auditable and presentable for external reviewers.
+
+Target stack suggestion (reference; replace as desired):
+
+* Backend: Node.js / TypeScript (Express/Fastify) or Python (FastAPI).
+* DB: Postgres (primary relational), pgvector or external vector DB (Pinecone/Weaviate) for embeddings.
+* Object store: S3-compatible (MinIO / AWS S3).
+* Stream processing: Kafka or Postgres logical replication for scale.
+* Automation: n8n for webhook-driven flows.
+* Frontend: Next.js + Tailwind or equivalent.
+* Auth/IAM: Keycloak or custom AD-like service; HashiCorp Vault for secrets.
+* Deployment: Docker + Kubernetes (or Proxmox VMs if private infra).
+* AI: OpenAI or local LLM for parsing, embeddings; careful model governance.
+
+---
+
+## 1 — High-level architecture
+
+1. **Ingest Layer**
+
+   * Receives file uploads, webhooks (email, payments), manual inputs, API calls.
+   * Immediately stores raw blobs in object storage and creates `media_object` records.
+   * Emits a canonical `ingest_event` into the event stream.
+
+2. **Parser & Normalizer**
+
+   * Deterministic parsers + AI parsers:
+
+     * Emails (.eml), PDFs, invoices, receipts, CSV lists, images (OCR), audio (speech → text).
+   * Outputs structured rows (purchase_orders, people, vendors, etc.) and `parser_confidence`.
+   * Low-confidence items pushed to human review queue.
+
+3. **Vectorizer**
+
+   * Text (extracted text), transcripts, and OCR → embeddings (store either in pgvector or vector DB).
+   * Embedding id referenced in relational row.
+
+4. **Event Stream & Store**
+
+   * Master append-only `events` table (bigserial) and/or Kafka topic.
+   * All operations produce events (user actions, agent actions, automated operations).
+
+5. **Relational DB (Postgres)**
+
+   * Canonical tables (strongly normalized).
+   * Every canonical field that could be reused is its own table (towns, vendors, platforms, products, etc.).
+
+6. **Agents & Intelligence Layer**
+
+   * Microservices that subscribe to events, run semantic search / classification / predictions, propose or execute actions.
+   * Agents also record their assumptions, seeds, config, and outputs (fully auditable).
+
+7. **Automation Layer (n8n)**
+
+   * Webhook endpoints for triggering flows; must be part of the event pipeline.
+   * n8n runs enrichment, external API calls, or internal triggers (e.g., create shipment, mark insurance).
+
+8. **Frontend (Next.js)**
+
+   * Command palette, mission control, entity pages, replay mode, simulation console, agent console, developer integrations.
+
+9. **Security & Governance**
+
+   * AD-like directory for users and service accounts. RBAC + ABAC (attributes like `llc_id`, `classification`, `role`).
+   * All events signed where appropriate; media hashed and stored; optional Merkle chain snapshots.
+   * Keys in Vault; encryption at rest and in transit.
+
+---
+
+## 2 — Primary goals for Codex to implement now
+
+1. Build a minimal working foundation that proves the core FOIP loop: ingest → parse → store → vectorize → event → agent suggestion.
+2. Make canonical relational model for core entities (LLC, people, events, media, vendors, purchases, shipments, assets, claims, transactions).
+3. Provide one UI flow: upload a purchase PDF → system parses → creates `purchase_order`, `vendor` (or links), `media_object`, `event`, and an asset record if delivered.
+4. Add semantic search (vector query) on documents + claim tracking.
+5. Implement an agent (FinanceAgent) prototype that suggests “create repayment plan” or “flag payment overdue” with an action button that creates an `events` entry when approved.
+
+---
+
+## 3 — Canonical data model (core tables + explanation)
+
+Below is an abbreviated DDL for the **core** objects. Use this as the master schema scaffold. After this core, additional tables (email lineage, call logs, SCIF visitors, backups, etc.) follow the same pattern.
+
+> Note: this is *starter DDL* — indexes, partitioning, and tuning come next. Also consider separating event store into partitioned table(s).
+
+### Core SQL DDL (Postgres — master set)
+
+```sql
+-- =======================================================
+-- MASTER ENTITIES
+-- =======================================================
+
+CREATE TABLE llcs (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  ein TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE people (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  name TEXT,
+  email TEXT,
+  phone TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE users (
+  id BIGSERIAL PRIMARY KEY,
+  person_id BIGINT REFERENCES people(id),
+  username TEXT UNIQUE,
+  display_name TEXT,
+  auth_provider TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE towns (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT UNIQUE
+);
+
+CREATE TABLE platforms (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT,
+  notes TEXT
+);
+
+CREATE TABLE vendors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT,
+  vendor_identifier TEXT,
+  platform_id BIGINT REFERENCES platforms(id),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- =======================================================
+-- MEDIA & VECTORS
+-- =======================================================
+
+CREATE TABLE media_objects (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  media_type TEXT, -- pdf, image, audio, eml, csv
+  mime TEXT,
+  s3_pointer TEXT,
+  sha256 TEXT,
+  extracted_text TEXT,
+  parsed_json JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE embeddings (
+  id BIGSERIAL PRIMARY KEY,
+  media_id BIGINT REFERENCES media_objects(id),
+  model_name TEXT,
+  vector_id TEXT,
+  dim INT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- =======================================================
+-- EVENT STREAM & CLAIMS
+-- =======================================================
+
+CREATE TABLE events (
+  id BIGSERIAL PRIMARY KEY,
+  ts TIMESTAMPTZ DEFAULT now(),
+  llc_id BIGINT REFERENCES llcs(id),
+  actor_type TEXT, -- user, agent, system, webhook
+  actor_id BIGINT,
+  event_type TEXT,
+  entity_type TEXT,
+  entity_id BIGINT,
+  payload JSONB,
+  media_id BIGINT REFERENCES media_objects(id),
+  signature TEXT,
+  hash TEXT
+);
+
+CREATE TABLE claims (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  claim_text TEXT,
+  source_event_id BIGINT REFERENCES events(id),
+  asserted_by_actor BIGINT,
+  asserted_at TIMESTAMPTZ DEFAULT now(),
+  confidence NUMERIC,
+  status TEXT DEFAULT 'unverified',
+  meta JSONB
+);
+
+CREATE TABLE claim_verifications (
+  id BIGSERIAL PRIMARY KEY,
+  claim_id BIGINT REFERENCES claims(id),
+  verifier_actor BIGINT,
+  verification_event_id BIGINT REFERENCES events(id),
+  result TEXT, -- supports, refutes, inconclusive
+  score NUMERIC,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- =======================================================
+-- PURCHASES & SUPPLY CHAIN
+-- =======================================================
+
+CREATE TABLE purchase_orders (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  vendor_id BIGINT REFERENCES vendors(id),
+  platform_id BIGINT REFERENCES platforms(id),
+  order_number TEXT,
+  currency TEXT,
+  total_amount NUMERIC,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  parsed_json JSONB
+);
+
+CREATE TABLE purchase_items (
+  id BIGSERIAL PRIMARY KEY,
+  purchase_order_id BIGINT REFERENCES purchase_orders(id),
+  description TEXT,
+  sku TEXT,
+  quantity INT,
+  unit_price NUMERIC,
+  meta JSONB
+);
+
+CREATE TABLE shipments (
+  id BIGSERIAL PRIMARY KEY,
+  purchase_order_id BIGINT REFERENCES purchase_orders(id),
+  carrier TEXT,
+  tracking_number TEXT,
+  insured BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  meta JSONB
+);
+
+CREATE TABLE shipment_events (
+  id BIGSERIAL PRIMARY KEY,
+  shipment_id BIGINT REFERENCES shipments(id),
+  event_ts TIMESTAMPTZ DEFAULT now(),
+  status TEXT,
+  location TEXT,
+  meta JSONB
+);
+
+CREATE TABLE assets (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  purchase_item_id BIGINT REFERENCES purchase_items(id),
+  serial_number TEXT,
+  current_status TEXT, -- in_transit, received, in_use, disposed
+  location_id BIGINT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- =======================================================
+-- TREASURY & ACCOUNTS
+-- =======================================================
+
+CREATE TABLE accounts (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  name TEXT,
+  account_type TEXT,
+  meta JSONB
+);
+
+CREATE TABLE transactions (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  account_id BIGINT REFERENCES accounts(id),
+  amount NUMERIC,
+  currency TEXT,
+  tx_type TEXT, -- credit, debit
+  reference TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  meta JSONB
+);
+
+-- =======================================================
+-- HR & DIRECTORY
+-- =======================================================
+
+CREATE TABLE employees (
+  id BIGSERIAL PRIMARY KEY,
+  person_id BIGINT REFERENCES people(id),
+  llc_id BIGINT REFERENCES llcs(id),
+  position TEXT,
+  hire_date DATE,
+  status TEXT,
+  meta JSONB
+);
+
+CREATE TABLE payroll (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT REFERENCES employees(id),
+  amount NUMERIC,
+  currency TEXT,
+  pay_date DATE,
+  meta JSONB
+);
+
+CREATE TABLE training_logs (
+  id BIGSERIAL PRIMARY KEY,
+  employee_id BIGINT REFERENCES employees(id),
+  training_name TEXT,
+  completed BOOLEAN,
+  completed_at TIMESTAMPTZ,
+  meta JSONB
+);
+
+-- =======================================================
+-- SCIF & SECURITY
+-- =======================================================
+
+CREATE TABLE scif_visitors (
+  id BIGSERIAL PRIMARY KEY,
+  name TEXT,
+  affiliation TEXT,
+  visit_date DATE,
+  purpose TEXT,
+  signed_in_by BIGINT REFERENCES users(id),
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE backups (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  backup_date TIMESTAMPTZ,
+  storage_pointer TEXT,
+  checksum TEXT,
+  status TEXT,
+  meta JSONB
+);
+
+CREATE TABLE sop_documents (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  title TEXT,
+  sop_text TEXT,
+  version INT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ
+);
+
+-- =======================================================
+-- COMMUNICATIONS
+-- =======================================================
+
+CREATE TABLE emails (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  from_address TEXT,
+  to_address TEXT,
+  subject TEXT,
+  body TEXT,
+  sent_at TIMESTAMPTZ,
+  media_id BIGINT REFERENCES media_objects(id)
+);
+
+CREATE TABLE call_logs (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  caller TEXT,
+  callee TEXT,
+  start_time TIMESTAMPTZ,
+  end_time TIMESTAMPTZ,
+  transcript TEXT,
+  media_id BIGINT REFERENCES media_objects(id)
+);
+
+-- =======================================================
+-- AGENTS, PLANS, SIMULATIONS
+-- =======================================================
+
+CREATE TABLE agents (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  name TEXT,
+  description TEXT,
+  config JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE plans (
+  id BIGSERIAL PRIMARY KEY,
+  llc_id BIGINT REFERENCES llcs(id),
+  name TEXT,
+  created_by BIGINT,
+  plan_json JSONB,
+  status TEXT DEFAULT 'draft',
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE simulations (
+  id BIGSERIAL PRIMARY KEY,
+  plan_id BIGINT REFERENCES plans(id),
+  inputs JSONB,
+  seed BIGINT,
+  model_version TEXT,
+  results JSONB,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- =======================================================
+-- AUDIT & OVERSIGHT
+-- =======================================================
+
+CREATE TABLE audit_entries (
+  id BIGSERIAL PRIMARY KEY,
+  event_id BIGINT REFERENCES events(id),
+  auditor_id BIGINT,
+  correction JSONB,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+> This is a core minimal set — add email tables, call logs, SCIF visitors, backups, SOPs, etc., following these patterns.
+
+---
+
+## 4 — Ingestion & webhook contracts (practical specs)
+
+Design a single, consistent webhook API for external connectors (n8n, mail provider, payment gateway). All webhooks must:
+
+* accept a signed payload (HMAC with shared secret),
+* return 2xx on success,
+* insert a raw `media_object` if contains files and emit an `ingest_event` into `events`.
+
+### Example webhook (POST /api/webhooks/ingest)
+
+Request headers:
+
+```
+X-Hub-Signature: sha256=<hmac>
+X-Source: mailgun | stripe | ebay | s3 | custom
+X-Sent-At: 2025-09-19T12:34:56Z
+```
+
+Body (JSON):
+
+```json
+{
+  "source":"mailgun",
+  "source_id":"MG-evt-abc123",
+  "llc_id": 1,
+  "raw_payload": { ... },       // full provider webhook JSON
+  "attachments": [
+    {
+      "filename":"invoice.pdf",
+      "content_base64":"...",
+      "mime":"application/pdf"
+    }
+  ],
+  "meta": {"received_ip":"1.2.3.4"}
+}
+```
+
+Server:
+
+* verify header HMAC,
+* store attachments to object store (`s3_pointer`),
+* create `media_objects` rows,
+* create `events` row `{event_type: "webhook_ingest", payload: raw_payload, media_id: ...}`.
+
+### Example event (events.payload)
+
+```json
+{
+  "raw": { /* raw webhook */ },
+  "parsed": { /* parser results (if synchronous) */ },
+  "source":"mailgun",
+  "source_id":"MG-evt-abc123"
+}
+```
+
+---
+
+## 5 — n8n flow outline (example)
+
+(Flow: webhook → store raw → parse → vectorize → insert structured rows → emit events)
+
+1. **Webhook Trigger**: /api/webhooks/ingest
+2. **Save Attachments**: write files to S3 (MinIO) — return s3 pointers.
+3. **POST to Parser Service**: send s3 pointers to parser endpoint; parser returns structured JSON + confidence.
+4. **DB Insert**: Insert `media_objects` + parsed structured rows (purchase_orders, people) via API backend.
+5. **Embedding Job**: call embedding function; store embedding id in DB or push to vector DB.
+6. **Emit Event**: POST to /api/events with canonical event payload.
+7. **Agent Trigger**: agent microservices subscribe to events (via Kafka/DB triggers) to run their logic.
+
+---
+
+## 6 — Agents & intelligence (design pattern)
+
+* Agents are event-driven microservices:
+
+  * subscribe to `events` (or Kafka topics),
+  * run a logic pipeline: enrich (relational + vector search) → score → propose action,
+  * propose action is recorded in `events` and shown in Agent Console for approval (or auto-executed if policy allows),
+  * every agent action recorded as `events` and `audit_entries`.
+
+**Agent examples**
+
+* FinanceAgent: predicts cash runway, recommends intercompany loan, suggests payments scheduling.
+* OpsAgent: monitors shipments, suggests alternate carrier on delay probability.
+* ComplianceAgent: scans contracts against SOP, flags missing clauses.
+* KnowledgeAgent: cluster docs, creates summaries and new SOP drafts.
+
+**Agent governance**
+
+* each agent must have a config (in `agents.config`), versioned,
+* each run stores inputs, model_version, seed, outputs in `simulations` or `agent_actions` table.
+
+---
+
+## 7 — Claims & falsehood handling
+
+Design `claims` as first-class objects:
+
+* every transcribed statement, extracted assertion, or user-entered claim produces a `claims` row referencing its `source_event_id`.
+* claims have **verification events**: attempts to validate supported/refute via evidence (shipments, logs, receipts).
+* the UI shows a claim timeline: asserted → verified/refuted/inconclusive → human review.
+* never delete or overwrite claims; always append verification events.
+
+---
+
+## 8 — UI/UX design (key screens & behaviors)
+
+### Global chrome
+
+* Left rail: LLC switcher (select an LLC context), modules list (Dashboard, Finance, Assets, HR, Comms, Agents, SCIF).
+* Top bar: command palette (⌘+C), global search (semantic + relational), quick-add.
+
+### Mission Control dashboard
+
+* Empire rollups: consolidated treasury, assets at risk, top alerts, current simulations.
+* Heat map / graph for inter-LLC flows, royalties, loans.
+
+### Entity page (contract, asset, purchase, person)
+
+* Header summary (canonical info).
+* Timeline (events) with filters (all / agent actions / user actions / webhooks).
+* Raw media (PDF, audio) with extracted text and vector similarity panel.
+* Related entities (linked contracts, invoices, people).
+* Claim panel (assertions + verifications).
+* Action buttons: create plan, start simulation, escalate to audit.
+
+### Command palette examples
+
+* “Log purchase from eBay seller xyz, order 123” → opens quick modal → creates purchase and event.
+* “Simulate 20% revenue drop for LLC-3” → run simulation UI, present outputs.
+* “Find documents similar to contract #456” → vector search results.
+
+### Replay Mode
+
+* Play events for an entity in chronological order, show media at time of event, allow step back/forward.
+
+### Agent Console
+
+* Pending suggestions, recommended actions, approvals, action history.
+
+---
+
+## 9 — Security & compliance
+
+**Identity**
+
+* Built-in AD-like directory: users/groups/roles. SSO (SAML/OAuth2) for enterprise.
+* Each user assigned attributes: allowed_llcs[], clearance_level, roles[].
+
+**Authentication**
+
+* MFA (TOTP + FIDO2 hardware keys).
+* Service accounts for agents with limited scopes.
+
+**Data protection**
+
+* Raw blobs encrypted with envelope encryption; keys in Vault.
+* Field-level redaction for Boardroom mode.
+* Logging of all accesses (create, read, update events are recorded — reads also logged if sensitive).
+
+**Immutability & provenance**
+
+* Events append-only; store hash + optional signature.
+* Optional periodic merkle-root snapshot of events for tamper-proof proofs.
+
+**Model governance**
+
+* Every model/agent run stores model_version, prompt, input dataset references, seed, outputs — all stored as events.
+
+**Legal / privacy**
+
+* Implement access controls for PII; provide export and redaction tools; maintain a compliance audit view.
+
+---
+
+## 10 — .env / configuration variables (minimum)
+
+```
+# Database
+DATABASE_URL=postgres://user:pass@db:5432/empire
+
+# Object store
+S3_ENDPOINT=https://minio.local
+S3_BUCKET=empire-raw
+S3_ACCESS_KEY=...
+S3_SECRET_KEY=...
+
+# Vector DB
+VECTOR_PROVIDER=pgvector|pinecone|weaviate
+VECTOR_DB_URL=...
+
+# Embeddings / LLM
+EMBEDDINGS_API_URL=https://api.openai.com/v1/embeddings
+EMBEDDINGS_API_KEY=sk-...
+
+# Webhook secret
+WEBHOOK_SECRET=supersecret
+
+# Agent config
+AGENT_SERVICE_URL=http://agents:9000
+AGENT_SIGNING_KEY=...
+
+# Security & Vault
+VAULT_ADDR=https://vault.local
+VAULT_TOKEN=...
+
+# App
+APP_HOST=0.0.0.0
+APP_PORT=3000
+JWT_SECRET=...
+
+# AD/SSO
+SSO_PROVIDER_URL=...
+SSO_CLIENT_ID=...
+SSO_CLIENT_SECRET=...
+
+# Merkle snapshot config
+MERKLE_WINDOW_SIZE=10000
+```
+
+---
+
+## 11 — Example event payloads (practical)
+
+**Webhook ingest event**
+
+```json
+{
+  "type":"webhook_ingest",
+  "source":"mailgun",
+  "source_id":"MG-evt-abc123",
+  "llc_id":1,
+  "raw_payload": {/* raw provider payload */},
+  "attachments":[{"s3_pointer":"s3://empire-raw/abc.pdf","sha256":"..."}]
+}
+```
+
+**Purchase created event**
+
+```json
+{
+  "type":"purchase_created",
+  "llc_id":1,
+  "actor_type":"system",
+  "actor_id":0,
+  "payload":{
+    "purchase_order_id":234,
+    "vendor_id":45,
+    "order_number":"123-XYZ",
+    "total_amount":125.50,
+    "currency":"USD"
+  },
+  "media_id": 999
+}
+```
+
+**Claim event**
+
+```json
+{
+  "type":"claim_logged",
+  "llc_id":1,
+  "actor_type":"user",
+  "actor_id":12,
+  "payload":{
+    "claim_id": 42,
+    "claim_text":"Vendor X always delivers on time"
+  },
+  "media_id": 400 -- (link to meeting transcript)
+}
+```
+
+---
+
+## 12 — Roadmap & milestones (practical timeline)
+
+### Phase 0 — Spec & infra (1-2 weeks)
+
+* Finalize DDL for core schema (llcs, events, media, claims, purchases, shipments).
+* Provision infra (Postgres, S3, vector DB, n8n, app skeleton).
+
+### Phase 1 — MVP (6–8 weeks)
+
+* Implement ingestion for CSV, PDF, .eml.
+* Insert parsed rows into DB and create events.
+* Basic UI: Mission Control + Entity page + command palette.
+* Implement pgvector + simple semantic search on media text.
+
+### Phase 2 — Core modules (8–12 weeks)
+
+* Finance (accounts, transactions), Purchases & Shipments, Asset lifecycle.
+* Agent: FinanceAgent prototype (cash runway suggestions + action button).
+* Audit queue & parser confidence human review UI.
+
+### Phase 3 — Intelligence & Simulation (8–12 weeks)
+
+* Improve agents (Ops, Compliance).
+* Implement simulations & scenario runner (Monte Carlo).
+* Add Merkle snapshot mechanism for immutability.
+
+### Phase 4 — Scale & Enterprise (ongoing)
+
+* AD integration, SSO, hardened deployment, full SCIF features, high-volume indexing and partitioning.
+
+---
+
+## 13 — Testing plan / acceptance criteria
+
+**Unit / Integration tests**
+
+* Parsers: given test artifacts (pdf invoice, .eml), they produce consistent structured rows and `media_object` with text extraction.
+* Event pipeline: webhook → media → events created → agent picked up event and proposed suggestion.
+* Vector search: known text cluster returns relevant documents within top-K.
+
+**E2E tests**
+
+* Upload sample purchase PDF → system creates purchase_order, purchase_items, shipment, asset, and event timeline. Replay mode shows full chain with media images.
+
+**Security tests**
+
+* SSO flows, RBAC enforcement, secrets retrieval from Vault, MFA tests.
+
+**Load tests**
+
+* Bulk ingestion (10k docs) with embedding and event insertion; measure throughput and vector DB behavior.
+
+---
+
+## 14 — Example developer tasks for Codex (first sprint)
+
+1. Create Postgres schema from DDL above and run migrations.
+2. Implement S3 object store integration and `media_objects` API.
+3. Implement webhook ingest endpoint (signed HMAC) and object storage for attachments.
+4. Implement a simple PDF OCR + parser microservice that extracts invoice fields and returns JSON.
+5. Implement event insertion after parse and a simple agent that listens for `purchase_created` to create a `transaction` placeholder.
+6. Build minimal Next.js UI: upload page, mission control with a list of recent events, entity page that shows events for a purchase.
+
+---
+
+## 15 — Helpful design notes & best practices
+
+* **Normalization first**: enforce FK checks early. If uncertain, ingest as `media_objects` + an event with parsed_json — then link later in normalization pass.
+* **Store raw + parsed**: never throw away raw bytes. Always keep `media_objects.raw_blob` pointer + parsed JSON.
+* **Parser confidence**: add parser confidence; use a human review queue for < threshold.
+* **Vectors outside Postgres if large**: for >100k vectors use Pinecone/Weaviate; keep vector_id in `embeddings`.
+* **Audit everything including reads for sensitive entities**.
+* **Agent actions are privileged**: require policy to auto-execute; otherwise queue for approval.
+* **Schema evolutions**: treat tables as data contracts; add `meta JSONB` rather than new columns in early iterations.
+* **Backups & recovery**: regular object-store snapshots + DB backups; store key verification artifacts in SCIF module.
+
+---
+
+## 16 — Example CLI / API endpoints (essential)
+
+* `POST /api/webhooks/ingest` — raw webhook ingest (HMAC signature)
+* `GET /api/events?llc_id=1&since=...` — stream events
+* `POST /api/media` — upload media directly (multipart/form-data)
+* `GET /api/entity/{type}/{id}` — canonical entity view (contract, purchase)
+* `POST /api/agents/{id}/run` — trigger agent run, returns simulation id
+* `POST /api/plans` — create plan
+* `POST /api/simulations/{id}/run` — run simulation
+* `POST /api/claims` — log a claim
+* `GET /api/embeddings/similar?query=...` — vector similarity search
+
+---
+
+## 17 — Deliverables Codex should produce in first PR
+
+* DB migration files for DDL above.
+* Webhook ingest endpoint.
+* Media upload service + S3 integration.
+* Parser microservice (PDF → parsed JSON) + test fixtures.
+* Event emitter that inserts to `events` table.
+* Basic Next.js UI: upload page + recent events feed + simple entity page (purchase view).
+* README with run instructions, .env template, and deploy notes.
+
+---
+
+## 18 — Operational & governance considerations
+
+* Define retention policy per data classification (PII may be restricted, but you stated you want to keep everything — ensure legal review).
+* Keep user access logs and make privacy controls visible to auditors.
+* Add a governance UI to manage agent policies (auto-execute thresholds, sensitive operations).
+* Schedule model reviews and version control (store all prompts & outputs).
+
+---
+
+## 19 — Agent → data domain mapping
+
+The tables above drive dozens of independent agents. Codex should wire each service to the appropriate event types and relational sources to guarantee complete coverage.
+
+### Finance & Treasury
+
+* **FinanceAgent** — tables: `transactions`, `accounts`, `purchase_orders`, `payroll`; events: `transaction_created`, `purchase_created`, `payroll_issued`.
+* **CreditAgent** — tables: `transactions`, `vendors`, `claims`; events: `transaction_defaulted`, `claim_logged`.
+* **InvestmentAgent** — tables: `assets`, `accounts`, `plans`, `simulations`; events: `asset_created`, `plan_created`, `simulation_run`.
+* **CostAgent** — tables: `transactions`, `accounts`, `subscriptions` (future); events: `transaction_created`, `subscription_created`.
+
+### Operations & Assets
+
+* **OpsAgent** — tables: `shipments`, `shipment_events`, `purchase_orders`; events: `shipment_event_logged`, `purchase_created`.
+* **AssetAgent** — tables: `assets`, `purchase_items`, `claims`; events: `asset_created`, `asset_disposed`, `claim_logged`.
+* **SupplyAgent** — tables: `vendors`, `purchase_orders`, `shipments`; events: `purchase_created`, `shipment_delayed`.
+* **InsuranceAgent** — tables: `shipments`, `assets`, `claims`; events: `shipment_created`, `claim_logged`.
+
+### Compliance & Governance
+
+* **ComplianceAgent** — tables: `contracts` (extension), `sop_documents`, `claims`; events: `contract_signed`, `sop_updated`, `claim_logged`.
+* **AuditAgent** — tables: `audit_entries`, `events`; events: `event_created`, `audit_correction_logged`.
+* **PolicyAgent** — tables: `sop_documents`, `claims`, `training_logs`; events: `sop_updated`, `claim_logged`, `training_completed`.
+
+### Human Resources
+
+* **HRAgent** — tables: `employees`, `payroll`; events: `employee_hired`, `payroll_issued`.
+* **TrainingAgent** — tables: `training_logs`, `employees`; events: `training_completed`, `training_assigned`.
+* **AccessAgent** — tables: `users`, `employees`, `roles` (extension); events: `user_created`, `role_changed`.
+
+### Knowledge & Documentation
+
+* **KnowledgeAgent** — tables: `media_objects`, `embeddings`, `sop_documents`; events: `media_ingested`, `embedding_created`, `sop_updated`.
+* **SOPAgent** — tables: `sop_documents`, `audit_entries`; events: `sop_updated`, `audit_correction_logged`.
+* **ClaimAgent** — tables: `claims`, `claim_verifications`; events: `claim_logged`, `claim_verification_added`.
+
+### Risk & Simulation
+
+* **RiskAgent** — tables: `transactions`, `claims`, `vendors`, `accounts`; events: `transaction_created`, `claim_logged`, `vendor_blacklisted`.
+* **SimulationAgent** — tables: `plans`, `simulations`, `assets`; events: `plan_created`, `simulation_run`.
+* **ForecastAgent** — tables: `transactions`, `shipments`, `payroll`; events: `transaction_created`, `shipment_event_logged`, `payroll_issued`.
+
+### Security & SCIF
+
+* **SecurityAgent** — tables: `events`, `users`, `audit_entries`; events: `user_login`, `event_created`, `audit_correction_logged`.
+* **SCIFAgent** — tables: `scif_visitors`, `backups`, `sop_documents`; events: `scif_visitor_logged`, `backup_created`, `sop_updated`.
+* **OPSECAgent** — tables: `vendors`, `transactions`, `claims`, `media_objects`; events: `media_ingested`, `claim_logged`, `transaction_created`.
+
+### Specialized coverage
+
+* **AnomalyAgent** — cross-table analytics over `events`, `claims`, `transactions`, `shipments`; reacts to aggregate anomaly detectors.
+* **ReputationAgent** — extends `claims` and `media_objects` with OSINT feeds; events: `claim_logged`, `media_ingested`.
+* **EthicsAgent** — tables: `claims`, `sop_documents`, `agents`; events: `claim_logged`, `agent_run`.
+
+Codex should persist agent configs in `agents.config`, version each deployment, and emit agent actions back into the `events` stream for audit.
+
+---
+
+## 20 — Event stream trigger scaffolding
+
+Append-only triggers keep downstream agents synchronized without bespoke plumbing. Implement the following PL/pgSQL functions (or equivalent logical decoding) during migration setup.
+
+### Transaction inserts → `transaction_created`
+
+```sql
+CREATE OR REPLACE FUNCTION log_transaction_event()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO events (
+    ts, llc_id, actor_type, actor_id, event_type,
+    entity_type, entity_id, payload
+  )
+  VALUES (
+    now(),
+    NEW.llc_id,
+    'system',
+    0,
+    'transaction_created',
+    'transaction',
+    NEW.id,
+    jsonb_build_object(
+      'account_id', NEW.account_id,
+      'amount', NEW.amount,
+      'currency', NEW.currency,
+      'tx_type', NEW.tx_type,
+      'reference', NEW.reference
+    )
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_transaction_event
+AFTER INSERT ON transactions
+FOR EACH ROW
+EXECUTE FUNCTION log_transaction_event();
+```
+
+### Shipment inserts → `shipment_created`
+
+```sql
+CREATE OR REPLACE FUNCTION log_shipment_event()
+RETURNS TRIGGER AS $$
+DECLARE
+  shipment_llc BIGINT;
+BEGIN
+  SELECT llc_id INTO shipment_llc FROM purchase_orders WHERE id = NEW.purchase_order_id;
+
+  INSERT INTO events (
+    ts, llc_id, actor_type, actor_id, event_type,
+    entity_type, entity_id, payload
+  )
+  VALUES (
+    now(),
+    shipment_llc,
+    'system',
+    0,
+    'shipment_created',
+    'shipment',
+    NEW.id,
+    jsonb_build_object(
+      'carrier', NEW.carrier,
+      'tracking_number', NEW.tracking_number,
+      'insured', NEW.insured
+    )
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_shipment_event
+AFTER INSERT ON shipments
+FOR EACH ROW
+EXECUTE FUNCTION log_shipment_event();
+```
+
+### Claim inserts → `claim_logged`
+
+```sql
+CREATE OR REPLACE FUNCTION log_claim_event()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO events (
+    ts, llc_id, actor_type, actor_id, event_type,
+    entity_type, entity_id, payload
+  )
+  VALUES (
+    now(),
+    NEW.llc_id,
+    'user',
+    COALESCE(NEW.asserted_by_actor, 0),
+    'claim_logged',
+    'claim',
+    NEW.id,
+    jsonb_build_object(
+      'claim_text', NEW.claim_text,
+      'confidence', NEW.confidence,
+      'status', NEW.status
+    )
+  );
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_claim_event
+AFTER INSERT ON claims
+FOR EACH ROW
+EXECUTE FUNCTION log_claim_event();
+```
+
+These triggers demonstrate the append-only contract. If Codex later needs update hooks (e.g., `shipment_events` status progression), create additional trigger pairs that emit delta events without mutating canonical rows, maintaining ledger integrity.
+
+---
+
+## 21 — Final words to Codex (concise handoff)
+
+Build the system as a layered platform: ingest → canonicalize → vectorize → eventize → reason (agents) → act (automations). Keep the relational model normalized and authoritative. Treat the event stream as the single source of provenance. Make vectors the semantic augmentation. Log everything — even falsehoods — but always link claims to evidence and verification attempts. Prioritize auditability, secure defaults, and a simple first MVP that proves ingestion → event → agent suggestion flow. Expand modules iteratively.
+
+---
+
+If additional artifacts are required next, choose from the following and request explicitly:
+
+* Full master DDL extended with auxiliary modules and indices.
+* n8n flow JSON for the ingestion pipeline.
+* Concrete agent prototype (FinanceAgent) with sample code, endpoint spec, and simulation JSON.

--- a/docs/wireframes/sales_operations.md
+++ b/docs/wireframes/sales_operations.md
@@ -1,0 +1,101 @@
+# Sales Operations Dashboard Wireframe
+
+## Widget Data Attributes
+
+### Kanban Pipeline
+- `pipeline_id`: Unique identifier for the active pipeline configuration.
+- `stage_id`: Immutable identifier for each stage used for routing API calls.
+- `stage_name`: Human-readable label for the stage.
+- `sequence`: Ordinal placement of the stage for column ordering.
+- `deal_id`: CRM opportunity identifier.
+- `deal_name`: Title of the opportunity.
+- `account_name`: Company or customer name associated with the deal.
+- `deal_value`: Monetary value for forecasting and totals.
+- `currency`: ISO currency code for monetary values.
+- `confidence`: Probability weighting applied to the revenue projection widget.
+- `close_date`: Estimated close date used in projections.
+- `rep_id`: Owner identifier that ties to rep-level analytics.
+- `rep_name`: Display name of the deal owner.
+- `owner_avatar_url`: Optional URL for rep imagery.
+- `last_activity_at`: Timestamp of the last logged interaction.
+- `next_step`: Planned action for the deal.
+- `tags`: Array of string labels for filters and automations.
+- `priority`: Enum used to surface escalations.
+- `webhook_subscription_ids`: External automation hooks to trigger on stage changes.
+
+### Call Metrics Console
+- `reporting_window`: Object containing `start_at` and `end_at` timestamps.
+- `rep_id`: Identifier matching the CRM owner.
+- `rep_name`: Display name for UI.
+- `call_volume`: Total outbound dials in the window.
+- `connect_rate`: Percentage of calls reaching a live contact.
+- `talk_time_minutes`: Aggregate talk time in minutes.
+- `avg_handle_time`: Average call duration.
+- `voicemail_drop_rate`: Percentage of automated voicemail drops.
+- `dialer_session_count`: Number of dialer launches per rep.
+- `dialer_launch_url`: Deep link that opens the integrated dialer.
+- `dialer_provider`: Enum describing the third-party dialer vendor.
+- `dialer_session_id`: Identifier for the most recent launch, used for webhook reconciliation.
+- `webhook_event_types`: Supported dialer events subscribed via webhook.
+- `last_synced_at`: Timestamp of the latest metric refresh.
+
+### Script Drawer
+- `script_id`: Unique identifier per script template.
+- `title`: Script title shown in the drawer.
+- `supported_stages`: Stage IDs that surface the script.
+- `channel`: Communication medium supported (phone, email, etc.).
+- `persona`: Target persona for personalization cues.
+- `script_body`: Markdown-compatible script content.
+- `dynamic_tokens`: Merge fields available for personalization.
+- `compliance_notes`: Required legal disclosures.
+- `playbook_links`: Supporting documentation references.
+- `dialer_shortcuts`: Key-value map of dialer hotkeys to actions.
+- `last_reviewed_at`: QA timestamp for content governance.
+
+### Revenue Projection
+- `forecast_window`: Date range (start/end) for forecast calculations.
+- `rep_id`: Identifier for the rep or team segment.
+- `rep_name`: Display label for the rep or segment.
+- `weighted_pipeline_value`: Sum of deal values multiplied by confidence.
+- `target_quota`: Target quota for the period.
+- `attainment`: Percentage progress toward quota.
+- `run_rate_projection`: Projected attainment based on pace.
+- `stage_breakdown`: Array detailing contributions by `stage_id`.
+- `scenario`: Enum describing forecast scenario (commit, best_case, stretch).
+- `updated_at`: Timestamp of the last forecast refresh.
+
+### Coaching Queue
+- `call_id`: Identifier for the recorded call.
+- `rep_id`: Owner of the call.
+- `rep_name`: Display name of the rep.
+- `call_date`: Timestamp of the conversation.
+- `call_duration_minutes`: Duration of the call.
+- `qa_score`: Quality assurance score.
+- `review_status`: Enum tracking coaching progress.
+- `coach_id`: Owner of the coaching task.
+- `coach_name`: Display name for the coach.
+- `call_recording_url`: Link to call recording asset.
+- `transcript_url`: Link to transcript for accessibility.
+- `focus_tags`: Topics or behaviors flagged for review.
+- `webhook_event_id`: Identifier tying coaching events to webhook payloads.
+- `follow_up_due_at`: Due date for coaching follow-up.
+
+## Integration Checkpoints
+
+### Pipeline Stage Identifiers
+- Maintain an immutable `stage_id` catalogue synchronized with the CRM to power kanban ordering, projections, and script eligibility.
+- Expose a metadata endpoint that returns the stage catalogue with `stage_id`, `stage_name`, `sequence`, and `is_closed_stage` flags for downstream services.
+- Provide webhook callbacks on stage transitions using the `webhook_subscription_ids` declared above so automation tools can react in near real time.
+
+### Dialer Launch & Webhook Capabilities
+- Support deep links (`dialer_launch_url`) that can pre-load dialer context with `rep_id`, `deal_id`, and `call_list_id` parameters.
+- Capture the `dialer_session_id` returned by the vendor SDK to correlate dialer events (connect, disposition, voicemail drop) with CRM updates.
+- Register webhook subscriptions for `webhook_event_types` such as `dialer.call.connected`, `dialer.call.dispositioned`, and `dialer.session.ended`, storing their callbacks for retry logic.
+- Confirm SSO compatibility or token exchange requirements when launching the dialer, and document fallback behavior for non-SSO reps.
+
+### Accessibility & Compliance Requirements
+- Provide keyboard navigation for kanban drag-and-drop, script drawer tabs, and coaching queue actions with visible focus states.
+- Ensure color contrast ratios meet WCAG AA across pipeline badges, metrics cards, and status pills.
+- Supply ARIA labels for interactive components, especially dialer launch buttons, script selection controls, and coaching action menus.
+- Surface `compliance_notes` and required disclosures in the script drawer with screen-reader-friendly markup.
+

--- a/fixtures/sales_ops/call_metrics_console.json
+++ b/fixtures/sales_ops/call_metrics_console.json
@@ -1,0 +1,65 @@
+{
+  "reporting_window": {
+    "start_at": "2024-09-16T00:00:00Z",
+    "end_at": "2024-09-20T23:59:59Z"
+  },
+  "call_metrics": [
+    {
+      "rep_id": "rep_01",
+      "rep_name": "Taylor Brooks",
+      "call_volume": 145,
+      "connect_rate": 0.32,
+      "talk_time_minutes": 415,
+      "avg_handle_time": 6.3,
+      "voicemail_drop_rate": 0.18,
+      "dialer_session_count": 5,
+      "dialer_launch_url": "https://dialer.example.com/launch?rep=rep_01",
+      "dialer_provider": "orion_dialer",
+      "dialer_session_id": "dial-7a891",
+      "webhook_event_types": [
+        "dialer.call.connected",
+        "dialer.call.dispositioned",
+        "dialer.session.ended"
+      ],
+      "last_synced_at": "2024-09-20T22:15:00Z"
+    },
+    {
+      "rep_id": "rep_02",
+      "rep_name": "Jordan Singh",
+      "call_volume": 162,
+      "connect_rate": 0.36,
+      "talk_time_minutes": 502,
+      "avg_handle_time": 7.1,
+      "voicemail_drop_rate": 0.14,
+      "dialer_session_count": 7,
+      "dialer_launch_url": "https://dialer.example.com/launch?rep=rep_02",
+      "dialer_provider": "orion_dialer",
+      "dialer_session_id": "dial-7a997",
+      "webhook_event_types": [
+        "dialer.call.connected",
+        "dialer.call.voicemail_drop",
+        "dialer.session.ended"
+      ],
+      "last_synced_at": "2024-09-20T22:10:00Z"
+    },
+    {
+      "rep_id": "rep_03",
+      "rep_name": "Morgan Patel",
+      "call_volume": 98,
+      "connect_rate": 0.29,
+      "talk_time_minutes": 341,
+      "avg_handle_time": 6.9,
+      "voicemail_drop_rate": 0.22,
+      "dialer_session_count": 4,
+      "dialer_launch_url": "https://dialer.example.com/launch?rep=rep_03",
+      "dialer_provider": "orion_dialer",
+      "dialer_session_id": "dial-7a743",
+      "webhook_event_types": [
+        "dialer.call.connected",
+        "dialer.call.dispositioned",
+        "dialer.call.voicemail_drop"
+      ],
+      "last_synced_at": "2024-09-20T22:05:00Z"
+    }
+  ]
+}

--- a/fixtures/sales_ops/coaching_queue.json
+++ b/fixtures/sales_ops/coaching_queue.json
@@ -1,0 +1,52 @@
+{
+  "reviews": [
+    {
+      "call_id": "call-9012",
+      "rep_id": "rep_01",
+      "rep_name": "Taylor Brooks",
+      "call_date": "2024-09-18T16:05:00Z",
+      "call_duration_minutes": 28,
+      "qa_score": 72,
+      "review_status": "pending",
+      "coach_id": "coach_01",
+      "coach_name": "Riley Chen",
+      "call_recording_url": "https://recordings.example.com/call-9012.mp3",
+      "transcript_url": "https://recordings.example.com/call-9012.vtt",
+      "focus_tags": ["discovery", "objection_handling"],
+      "webhook_event_id": "wh_call_qa_required",
+      "follow_up_due_at": "2024-09-22T23:59:00Z"
+    },
+    {
+      "call_id": "call-9018",
+      "rep_id": "rep_02",
+      "rep_name": "Jordan Singh",
+      "call_date": "2024-09-19T15:40:00Z",
+      "call_duration_minutes": 34,
+      "qa_score": 86,
+      "review_status": "in_review",
+      "coach_id": "coach_02",
+      "coach_name": "Jamie Alvarez",
+      "call_recording_url": "https://recordings.example.com/call-9018.mp3",
+      "transcript_url": "https://recordings.example.com/call-9018.vtt",
+      "focus_tags": ["pricing", "next_steps"],
+      "webhook_event_id": "wh_call_review_started",
+      "follow_up_due_at": "2024-09-23T18:00:00Z"
+    },
+    {
+      "call_id": "call-9021",
+      "rep_id": "rep_03",
+      "rep_name": "Morgan Patel",
+      "call_date": "2024-09-20T13:10:00Z",
+      "call_duration_minutes": 21,
+      "qa_score": 91,
+      "review_status": "completed",
+      "coach_id": "coach_01",
+      "coach_name": "Riley Chen",
+      "call_recording_url": "https://recordings.example.com/call-9021.mp3",
+      "transcript_url": "https://recordings.example.com/call-9021.vtt",
+      "focus_tags": ["value_messaging", "closing"],
+      "webhook_event_id": "wh_call_review_completed",
+      "follow_up_due_at": "2024-09-21T20:00:00Z"
+    }
+  ]
+}

--- a/fixtures/sales_ops/pipeline_kanban.json
+++ b/fixtures/sales_ops/pipeline_kanban.json
@@ -1,0 +1,142 @@
+{
+  "pipeline_id": "enterprise_pipeline_q4",
+  "stages": [
+    {
+      "stage_id": "stage_qualification",
+      "stage_name": "Qualification",
+      "sequence": 1,
+      "deals": [
+        {
+          "deal_id": "D-1001",
+          "deal_name": "Acme Platform Rollout",
+          "account_name": "Acme Manufacturing",
+          "deal_value": 85000,
+          "currency": "USD",
+          "confidence": 0.35,
+          "close_date": "2024-11-15",
+          "rep_id": "rep_01",
+          "rep_name": "Taylor Brooks",
+          "owner_avatar_url": "https://cdn.example.com/avatars/taylor_brooks.png",
+          "last_activity_at": "2024-09-18T14:22:00Z",
+          "next_step": "Schedule technical discovery",
+          "tags": ["manufacturing", "expansion"],
+          "priority": "medium",
+          "webhook_subscription_ids": ["wh_kanban_move_acme"]
+        },
+        {
+          "deal_id": "D-1005",
+          "deal_name": "Northwind Data Alignment",
+          "account_name": "Northwind Analytics",
+          "deal_value": 54000,
+          "currency": "USD",
+          "confidence": 0.3,
+          "close_date": "2024-10-20",
+          "rep_id": "rep_02",
+          "rep_name": "Jordan Singh",
+          "owner_avatar_url": "https://cdn.example.com/avatars/jordan_singh.png",
+          "last_activity_at": "2024-09-19T09:40:00Z",
+          "next_step": "Send ROI calculator",
+          "tags": ["saas", "pilot"],
+          "priority": "high",
+          "webhook_subscription_ids": ["wh_kanban_move_northwind"]
+        }
+      ]
+    },
+    {
+      "stage_id": "stage_discovery",
+      "stage_name": "Discovery",
+      "sequence": 2,
+      "deals": [
+        {
+          "deal_id": "D-1003",
+          "deal_name": "Globex Workflow Automation",
+          "account_name": "Globex Corporation",
+          "deal_value": 132000,
+          "currency": "USD",
+          "confidence": 0.45,
+          "close_date": "2024-12-05",
+          "rep_id": "rep_01",
+          "rep_name": "Taylor Brooks",
+          "owner_avatar_url": "https://cdn.example.com/avatars/taylor_brooks.png",
+          "last_activity_at": "2024-09-17T17:55:00Z",
+          "next_step": "Deliver solution design",
+          "tags": ["enterprise", "workflow"],
+          "priority": "medium",
+          "webhook_subscription_ids": ["wh_kanban_move_globex"]
+        }
+      ]
+    },
+    {
+      "stage_id": "stage_proposal",
+      "stage_name": "Proposal",
+      "sequence": 3,
+      "deals": [
+        {
+          "deal_id": "D-1002",
+          "deal_name": "Initech Analytics Upgrade",
+          "account_name": "Initech",
+          "deal_value": 97000,
+          "currency": "USD",
+          "confidence": 0.6,
+          "close_date": "2024-10-30",
+          "rep_id": "rep_03",
+          "rep_name": "Morgan Patel",
+          "owner_avatar_url": "https://cdn.example.com/avatars/morgan_patel.png",
+          "last_activity_at": "2024-09-20T15:10:00Z",
+          "next_step": "Negotiate procurement terms",
+          "tags": ["renewal", "analytics"],
+          "priority": "high",
+          "webhook_subscription_ids": ["wh_kanban_move_initech"]
+        }
+      ]
+    },
+    {
+      "stage_id": "stage_negotiation",
+      "stage_name": "Negotiation",
+      "sequence": 4,
+      "deals": [
+        {
+          "deal_id": "D-1004",
+          "deal_name": "Wayne Enterprises Compliance",
+          "account_name": "Wayne Enterprises",
+          "deal_value": 156000,
+          "currency": "USD",
+          "confidence": 0.75,
+          "close_date": "2024-11-12",
+          "rep_id": "rep_02",
+          "rep_name": "Jordan Singh",
+          "owner_avatar_url": "https://cdn.example.com/avatars/jordan_singh.png",
+          "last_activity_at": "2024-09-18T19:20:00Z",
+          "next_step": "Finalize legal review",
+          "tags": ["security", "compliance"],
+          "priority": "urgent",
+          "webhook_subscription_ids": ["wh_kanban_move_wayne"]
+        }
+      ]
+    },
+    {
+      "stage_id": "stage_closed_won",
+      "stage_name": "Closed Won",
+      "sequence": 5,
+      "deals": [
+        {
+          "deal_id": "D-1006",
+          "deal_name": "Stark Industries Data Lake",
+          "account_name": "Stark Industries",
+          "deal_value": 210000,
+          "currency": "USD",
+          "confidence": 1.0,
+          "close_date": "2024-09-01",
+          "rep_id": "rep_03",
+          "rep_name": "Morgan Patel",
+          "owner_avatar_url": "https://cdn.example.com/avatars/morgan_patel.png",
+          "last_activity_at": "2024-09-01T12:00:00Z",
+          "next_step": "Kickoff implementation",
+          "tags": ["expansion", "strategic"],
+          "priority": "medium",
+          "webhook_subscription_ids": ["wh_kanban_move_stark"]
+        }
+      ]
+    }
+  ]
+}

--- a/fixtures/sales_ops/revenue_projection.json
+++ b/fixtures/sales_ops/revenue_projection.json
@@ -1,0 +1,80 @@
+{
+  "forecast_window": {
+    "start_at": "2024-09-01",
+    "end_at": "2024-12-31"
+  },
+  "projections": [
+    {
+      "rep_id": "rep_01",
+      "rep_name": "Taylor Brooks",
+      "weighted_pipeline_value": 168500,
+      "target_quota": 250000,
+      "attainment": 0.54,
+      "run_rate_projection": 0.88,
+      "stage_breakdown": [
+        {
+          "stage_id": "stage_qualification",
+          "weighted_value": 29750
+        },
+        {
+          "stage_id": "stage_discovery",
+          "weighted_value": 59400
+        },
+        {
+          "stage_id": "stage_proposal",
+          "weighted_value": 79250
+        }
+      ],
+      "scenario": "best_case",
+      "updated_at": "2024-09-20T21:30:00Z"
+    },
+    {
+      "rep_id": "rep_02",
+      "rep_name": "Jordan Singh",
+      "weighted_pipeline_value": 210600,
+      "target_quota": 260000,
+      "attainment": 0.62,
+      "run_rate_projection": 0.95,
+      "stage_breakdown": [
+        {
+          "stage_id": "stage_qualification",
+          "weighted_value": 48600
+        },
+        {
+          "stage_id": "stage_negotiation",
+          "weighted_value": 117000
+        },
+        {
+          "stage_id": "stage_closed_won",
+          "weighted_value": 45000
+        }
+      ],
+      "scenario": "commit",
+      "updated_at": "2024-09-20T21:32:00Z"
+    },
+    {
+      "rep_id": "rep_03",
+      "rep_name": "Morgan Patel",
+      "weighted_pipeline_value": 258700,
+      "target_quota": 275000,
+      "attainment": 0.74,
+      "run_rate_projection": 1.08,
+      "stage_breakdown": [
+        {
+          "stage_id": "stage_proposal",
+          "weighted_value": 116400
+        },
+        {
+          "stage_id": "stage_negotiation",
+          "weighted_value": 87300
+        },
+        {
+          "stage_id": "stage_closed_won",
+          "weighted_value": 55000
+        }
+      ],
+      "scenario": "stretch",
+      "updated_at": "2024-09-20T21:28:00Z"
+    }
+  ]
+}

--- a/fixtures/sales_ops/script_drawer.json
+++ b/fixtures/sales_ops/script_drawer.json
@@ -1,0 +1,46 @@
+{
+  "scripts": [
+    {
+      "script_id": "script_stage_qualification_connect",
+      "title": "Qualification Connect Script",
+      "supported_stages": ["stage_qualification"],
+      "channel": "phone",
+      "persona": "operations_director",
+      "script_body": "**Opening**\\nHi {{contact.first_name}}, this is {{user.first_name}} with Nimbus Analytics.\\n\\n**Value Statement**\\nWe help operations leaders reduce manual reporting by 40% through real-time dashboards.\\n\\n**Discovery Questions**\\n1. How are you currently consolidating performance metrics?\\n2. What triggers your team to investigate dips in output?\\n\\n**Next Step**\\nIf it makes sense, I can line up a discovery with one of our solution architects. Does Tuesday morning work?",
+      "dynamic_tokens": ["contact.first_name", "user.first_name"],
+      "compliance_notes": "Mention that all calls are recorded for quality and training purposes.",
+      "playbook_links": [
+        "https://intranet.example.com/playbooks/qualification",
+        "https://intranet.example.com/security-overview"
+      ],
+      "dialer_shortcuts": {
+        "ctrl+shift+d": "Drop pre-recorded voicemail",
+        "ctrl+enter": "Log connect disposition"
+      },
+      "last_reviewed_at": "2024-08-30T18:00:00Z"
+    },
+    {
+      "script_id": "script_stage_negotiation_value",
+      "title": "Negotiation Value Reinforcement",
+      "supported_stages": ["stage_negotiation", "stage_proposal"],
+      "channel": "phone",
+      "persona": "cfo",
+      "script_body": "**Reframe**\\n{{contact.first_name}}, I wanted to revisit the financial outcomes we modeled last week.\\n\\n**Value Proof**\\n- ${{deal.pipeline_savings}} annual reduction in manual reconciliation hours.\\n- ${{deal.error_cost_avoidance}} saved by alert-driven compliance workflows.\\n\\n**Ask**\\nAre there any procurement blockers we can resolve before your fiscal close on {{deal.fiscal_close_date}}?",
+      "dynamic_tokens": [
+        "contact.first_name",
+        "deal.pipeline_savings",
+        "deal.error_cost_avoidance",
+        "deal.fiscal_close_date"
+      ],
+      "compliance_notes": "Confirm NDA coverage before sharing detailed pricing.",
+      "playbook_links": [
+        "https://intranet.example.com/playbooks/negotiation"
+      ],
+      "dialer_shortcuts": {
+        "ctrl+shift+l": "Launch pricing calculator",
+        "ctrl+shift+w": "Open webhook-triggered win plan"
+      },
+      "last_reviewed_at": "2024-09-05T16:45:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace the Empire OS data model excerpt with the full master DDL covering media, treasury, HR, SCIF, comms, and audit modules
- document detailed agent-to-domain event subscriptions so each service knows which tables and events to follow
- add append-only trigger templates for transactions, shipments, and claims to wire the relational schema into the event stream

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68cdf8886008832dba39eddeb7dbe6e5