### PR TITLE
Add Empire OS prototype backend with ingestion pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.db
+storage/
+.empire/
+*.egg-info/
+.pytest_cache/
+.env

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Empire OS prototype package."""
+
+__all__ = ["create_app"]
+
+from .main import create_app  # noqa: E402

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,42 @@
+"""Database utilities for the Empire OS prototype."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+DATABASE_URL = "sqlite:///./empire.db"
+
+engine = create_engine(
+    DATABASE_URL,
+    connect_args={"check_same_thread": False},
+)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False)
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Import models and create all tables."""
+    from . import models  # noqa: F401  # Ensure models are registered
+
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """FastAPI dependency that yields a database session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+@contextmanager
+def override_session(session: Session) -> Generator[Session, None, None]:
+    """Context manager to temporarily yield an existing session (used in tests)."""
+    try:
+        yield session
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,93 @@
+"""FastAPI application wiring for Empire OS prototype."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+from .database import get_db, init_db
+from .services.agent import FinanceAgent
+from .services.ingest import IngestService, list_events, search_documents
+
+
+def create_app() -> FastAPI:
+    init_db()
+    app = FastAPI(title="Empire OS Prototype", version="0.1.0")
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.post("/ingest/purchase", response_model=schemas.PurchaseIngestResponse)
+    def ingest_purchase(
+        llc_name: str = Form(...),
+        file: UploadFile = File(...),
+        db: Session = Depends(get_db),
+    ) -> schemas.PurchaseIngestResponse:
+        llc = db.query(models.LLC).filter(models.LLC.name == llc_name).one_or_none()
+        if not llc:
+            llc = models.LLC(name=llc_name)
+            db.add(llc)
+            db.commit()
+            db.refresh(llc)
+
+        service = IngestService(db)
+        purchase_order, events, suggestions = service.ingest_purchase(llc, file)
+        return schemas.PurchaseIngestResponse(
+            purchase_order=purchase_order,
+            events=events,
+            suggestions=suggestions,
+        )
+
+    @app.get("/events", response_model=List[schemas.Event])
+    def get_events(limit: int = 50, db: Session = Depends(get_db)) -> List[schemas.Event]:
+        return list(list_events(db, limit=limit))
+
+    @app.get("/purchase_orders", response_model=List[schemas.PurchaseOrder])
+    def get_purchase_orders(db: Session = Depends(get_db)) -> List[schemas.PurchaseOrder]:
+        return db.query(models.PurchaseOrder).order_by(models.PurchaseOrder.created_at.desc()).all()
+
+    @app.get("/search/documents", response_model=List[schemas.SearchResult])
+    def search(query: str, db: Session = Depends(get_db)) -> List[schemas.SearchResult]:
+        results = search_documents(db, query)
+        payload: List[schemas.SearchResult] = []
+        for media, score in results:
+            excerpt = Path(media.storage_path).read_text(errors="ignore")[:160] if media.storage_path else ""
+            payload.append(
+                schemas.SearchResult(
+                    media_object_id=media.id,
+                    score=score,
+                    excerpt=excerpt,
+                )
+            )
+        return payload
+
+    @app.post("/agents/suggestions/{suggestion_id}/approve", response_model=schemas.SuggestionApprovalResponse)
+    def approve_suggestion(
+        suggestion_id: int,
+        db: Session = Depends(get_db),
+    ) -> schemas.SuggestionApprovalResponse:
+        suggestion = db.get(models.AgentSuggestion, suggestion_id)
+        if not suggestion:
+            raise HTTPException(status_code=404, detail="Suggestion not found")
+        if suggestion.approved:
+            raise HTTPException(status_code=400, detail="Suggestion already approved")
+        agent = FinanceAgent(db)
+        event = agent.approve_suggestion(suggestion)
+        db.commit()
+        db.refresh(suggestion)
+        db.refresh(event)
+        return schemas.SuggestionApprovalResponse(suggestion=suggestion, event=event)
+
+    return app
+
+
+app = create_app()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,193 @@
+"""SQLAlchemy models for the Empire OS prototype."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.sqlite import JSON
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class LLC(Base):
+    __tablename__ = "llcs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    ein: Mapped[str | None] = mapped_column(String, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    people: Mapped[list["Person"]] = relationship(back_populates="llc", cascade="all, delete-orphan")
+    media_objects: Mapped[list["MediaObject"]] = relationship(back_populates="llc")
+    purchase_orders: Mapped[list["PurchaseOrder"]] = relationship(back_populates="llc")
+
+
+class Person(Base):
+    __tablename__ = "people"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    llc_id: Mapped[int | None] = mapped_column(ForeignKey("llcs.id"))
+    name: Mapped[str | None] = mapped_column(String)
+    email: Mapped[str | None] = mapped_column(String)
+    phone: Mapped[str | None] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    llc: Mapped[Optional["LLC"]] = relationship(back_populates="people")
+    user: Mapped[Optional["User"]] = relationship(back_populates="person", uselist=False)
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    person_id: Mapped[int | None] = mapped_column(ForeignKey("people.id"))
+    username: Mapped[str | None] = mapped_column(String, unique=True)
+    display_name: Mapped[str | None] = mapped_column(String)
+    auth_provider: Mapped[str | None] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    person: Mapped[Optional["Person"]] = relationship(back_populates="user")
+
+
+class Town(Base):
+    __tablename__ = "towns"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String, unique=True)
+
+
+class Platform(Base):
+    __tablename__ = "platforms"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str | None] = mapped_column(String)
+    notes: Mapped[str | None] = mapped_column(Text)
+
+    vendors: Mapped[list["Vendor"]] = relationship(back_populates="platform")
+
+
+class Vendor(Base):
+    __tablename__ = "vendors"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str | None] = mapped_column(String)
+    vendor_identifier: Mapped[str | None] = mapped_column(String)
+    platform_id: Mapped[int | None] = mapped_column(ForeignKey("platforms.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    platform: Mapped[Optional["Platform"]] = relationship(back_populates="vendors")
+    purchase_orders: Mapped[list["PurchaseOrder"]] = relationship(back_populates="vendor")
+
+
+class MediaObject(Base):
+    __tablename__ = "media_objects"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    llc_id: Mapped[int | None] = mapped_column(ForeignKey("llcs.id"))
+    media_type: Mapped[str | None] = mapped_column(String)
+    mime: Mapped[str | None] = mapped_column(String)
+    storage_path: Mapped[str | None] = mapped_column(String)
+    sha256: Mapped[str | None] = mapped_column(String)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    llc: Mapped[Optional["LLC"]] = relationship(back_populates="media_objects")
+    purchase_orders: Mapped[list["PurchaseOrder"]] = relationship(back_populates="media_object")
+    vectors: Mapped[list["DocumentVector"]] = relationship(back_populates="media_object", cascade="all, delete-orphan")
+
+
+class DocumentVector(Base):
+    __tablename__ = "document_vectors"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    media_object_id: Mapped[int] = mapped_column(ForeignKey("media_objects.id"))
+    vector: Mapped[list[float]] = mapped_column(JSON)
+    embedding_strategy: Mapped[str] = mapped_column(String, default="hash-v1")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    media_object: Mapped["MediaObject"] = relationship(back_populates="vectors")
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    event_type: Mapped[str] = mapped_column(String)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+
+class PurchaseOrder(Base):
+    __tablename__ = "purchase_orders"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    llc_id: Mapped[int] = mapped_column(ForeignKey("llcs.id"))
+    vendor_id: Mapped[int] = mapped_column(ForeignKey("vendors.id"))
+    media_object_id: Mapped[int] = mapped_column(ForeignKey("media_objects.id"))
+    total_amount: Mapped[float] = mapped_column(Float)
+    currency: Mapped[str] = mapped_column(String, default="USD")
+    status: Mapped[str] = mapped_column(String, default="pending")
+    due_date: Mapped[datetime | None] = mapped_column(DateTime)
+    received_at: Mapped[datetime | None] = mapped_column(DateTime)
+    description: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    llc: Mapped["LLC"] = relationship(back_populates="purchase_orders")
+    vendor: Mapped["Vendor"] = relationship(back_populates="purchase_orders")
+    media_object: Mapped["MediaObject"] = relationship(back_populates="purchase_orders")
+    assets: Mapped[list["Asset"]] = relationship(back_populates="purchase_order", cascade="all, delete-orphan")
+    suggestions: Mapped[list["AgentSuggestion"]] = relationship(back_populates="purchase_order", cascade="all, delete-orphan")
+
+
+class Asset(Base):
+    __tablename__ = "assets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    purchase_order_id: Mapped[int] = mapped_column(ForeignKey("purchase_orders.id"))
+    name: Mapped[str] = mapped_column(String)
+    status: Mapped[str] = mapped_column(String, default="pending")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    purchase_order: Mapped["PurchaseOrder"] = relationship(back_populates="assets")
+
+
+class Claim(Base):
+    __tablename__ = "claims"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    purchase_order_id: Mapped[int | None] = mapped_column(ForeignKey("purchase_orders.id"))
+    description: Mapped[str | None] = mapped_column(Text)
+    status: Mapped[str] = mapped_column(String, default="open")
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    purchase_order: Mapped[Optional["PurchaseOrder"]] = relationship()
+
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    purchase_order_id: Mapped[int | None] = mapped_column(ForeignKey("purchase_orders.id"))
+    amount: Mapped[float] = mapped_column(Float)
+    currency: Mapped[str] = mapped_column(String, default="USD")
+    direction: Mapped[str] = mapped_column(String, default="outgoing")
+    happened_at: Mapped[datetime | None] = mapped_column(DateTime)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+
+    purchase_order: Mapped[Optional["PurchaseOrder"]] = relationship()
+
+
+class AgentSuggestion(Base):
+    __tablename__ = "agent_suggestions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    purchase_order_id: Mapped[int] = mapped_column(ForeignKey("purchase_orders.id"))
+    agent_name: Mapped[str] = mapped_column(String)
+    suggestion_type: Mapped[str] = mapped_column(String)
+    message: Mapped[str] = mapped_column(Text)
+    approved: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime)
+
+    purchase_order: Mapped["PurchaseOrder"] = relationship(back_populates="suggestions")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,79 @@
+"""Pydantic schemas for the Empire OS prototype."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class MediaObject(BaseModel):
+    id: int
+    media_type: Optional[str]
+    mime: Optional[str]
+    storage_path: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class Vendor(BaseModel):
+    id: int
+    name: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class PurchaseOrder(BaseModel):
+    id: int
+    total_amount: float
+    currency: str
+    status: str
+    due_date: Optional[datetime]
+    description: Optional[str]
+    vendor: Vendor
+    media_object: MediaObject
+
+    class Config:
+        orm_mode = True
+
+
+class Event(BaseModel):
+    id: int
+    event_type: str
+    payload: dict
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class AgentSuggestion(BaseModel):
+    id: int
+    agent_name: str
+    suggestion_type: str
+    message: str
+    approved: bool
+    created_at: datetime
+    approved_at: Optional[datetime]
+
+    class Config:
+        orm_mode = True
+
+
+class PurchaseIngestResponse(BaseModel):
+    purchase_order: PurchaseOrder
+    events: List[Event]
+    suggestions: List[AgentSuggestion]
+
+
+class SearchResult(BaseModel):
+    media_object_id: int
+    score: float = Field(..., ge=0)
+    excerpt: str
+
+
+class SuggestionApprovalResponse(BaseModel):
+    suggestion: AgentSuggestion
+    event: Event

--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1,0 +1,61 @@
+"""Finance agent prototype."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+class FinanceAgent:
+    """Simple heuristic finance agent to surface overdue or large purchases."""
+
+    def __init__(self, session: Session) -> None:
+        self.session = session
+
+    def evaluate_purchase_order(self, purchase_order: models.PurchaseOrder) -> list[models.AgentSuggestion]:
+        suggestions: list[models.AgentSuggestion] = []
+
+        if purchase_order.due_date:
+            now = datetime.now(timezone.utc)
+            if purchase_order.due_date.replace(tzinfo=timezone.utc) < now and purchase_order.status != "paid":
+                suggestions.append(
+                    models.AgentSuggestion(
+                        purchase_order=purchase_order,
+                        agent_name="FinanceAgent",
+                        suggestion_type="flag-overdue",
+                        message="Payment appears overdue. Flag for follow-up.",
+                    )
+                )
+
+        if purchase_order.total_amount >= 10000:
+            suggestions.append(
+                models.AgentSuggestion(
+                    purchase_order=purchase_order,
+                    agent_name="FinanceAgent",
+                    suggestion_type="create-repayment-plan",
+                    message="Consider creating a repayment plan for this large purchase.",
+                )
+            )
+
+        for suggestion in suggestions:
+            self.session.add(suggestion)
+        self.session.flush()
+        return suggestions
+
+    def approve_suggestion(self, suggestion: models.AgentSuggestion) -> models.Event:
+        suggestion.approved = True
+        suggestion.approved_at = datetime.now(timezone.utc)
+        event = models.Event(
+            event_type="agent_suggestion.approved",
+            payload={
+                "suggestion_id": suggestion.id,
+                "agent_name": suggestion.agent_name,
+                "suggestion_type": suggestion.suggestion_type,
+                "message": suggestion.message,
+            },
+        )
+        self.session.add(event)
+        self.session.flush()
+        return event

--- a/app/services/ingest.py
+++ b/app/services/ingest.py
@@ -1,0 +1,137 @@
+"""Ingestion orchestration for Empire OS prototype."""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Tuple
+
+from fastapi import UploadFile
+from sqlalchemy.orm import Session
+
+from .. import models
+from .agent import FinanceAgent
+from .parser import PurchaseParser, parser_event_payload
+from .vectorizer import embed_text
+
+MEDIA_ROOT = Path("storage")
+MEDIA_ROOT.mkdir(exist_ok=True)
+
+
+class IngestService:
+    def __init__(self, session: Session) -> None:
+        self.session = session
+        self.parser = PurchaseParser()
+
+    def ingest_purchase(self, llc: models.LLC, upload: UploadFile) -> Tuple[models.PurchaseOrder, list[models.Event], list[models.AgentSuggestion]]:
+        raw_bytes = upload.file.read()
+        text = raw_bytes.decode("utf-8", errors="ignore")
+
+        media = self._store_media(llc, upload.filename or "purchase.txt", raw_bytes, upload.content_type or "text/plain")
+        parsed, confidence = self.parser.parse_text(text)
+        vendor = self._get_or_create_vendor(parsed.vendor_name)
+        purchase_order = models.PurchaseOrder(
+            llc=llc,
+            vendor=vendor,
+            media_object=media,
+            total_amount=parsed.total_amount,
+            currency=parsed.currency,
+            due_date=parsed.due_date,
+            description=parsed.description,
+        )
+        self.session.add(purchase_order)
+
+        if parsed.asset_name:
+            asset = models.Asset(purchase_order=purchase_order, name=parsed.asset_name, status="pending")
+            self.session.add(asset)
+
+        events = self._create_events(
+            media=media,
+            llc=llc,
+            parsed_payload=parser_event_payload(parsed, confidence),
+            purchase_order=purchase_order,
+        )
+
+        vector = models.DocumentVector(media_object=media, vector=embed_text(text))
+        self.session.add(vector)
+
+        agent = FinanceAgent(self.session)
+        suggestions = agent.evaluate_purchase_order(purchase_order)
+
+        self.session.commit()
+        self.session.refresh(purchase_order)
+        for event in events:
+            self.session.refresh(event)
+        for suggestion in suggestions:
+            self.session.refresh(suggestion)
+
+        return purchase_order, events, suggestions
+
+    def _store_media(self, llc: models.LLC, filename: str, raw_bytes: bytes, mime: str) -> models.MediaObject:
+        sha = hashlib.sha256(raw_bytes).hexdigest()
+        storage_path = MEDIA_ROOT / f"{datetime.utcnow().timestamp()}_{filename}"
+        storage_path.write_bytes(raw_bytes)
+        media = models.MediaObject(
+            llc=llc,
+            media_type="document",
+            mime=mime,
+            storage_path=str(storage_path),
+            sha256=sha,
+        )
+        self.session.add(media)
+        self.session.flush()
+        return media
+
+    def _get_or_create_vendor(self, name: str) -> models.Vendor:
+        vendor = self.session.query(models.Vendor).filter(models.Vendor.name == name).one_or_none()
+        if vendor:
+            return vendor
+        vendor = models.Vendor(name=name)
+        self.session.add(vendor)
+        self.session.flush()
+        return vendor
+
+    def _create_events(
+        self,
+        *,
+        media: models.MediaObject,
+        llc: models.LLC,
+        parsed_payload: dict,
+        purchase_order: models.PurchaseOrder,
+    ) -> list[models.Event]:
+        ingest_event = models.Event(
+            event_type="ingest.received",
+            payload={"llc_id": llc.id, "media_object_id": media.id},
+        )
+        parsed_event = models.Event(
+            event_type="ingest.parsed",
+            payload=parsed_payload,
+        )
+        purchase_event = models.Event(
+            event_type="purchase_order.created",
+            payload={"purchase_order_id": purchase_order.id},
+        )
+        events = [ingest_event, parsed_event, purchase_event]
+        for event in events:
+            self.session.add(event)
+        self.session.flush()
+        return events
+
+
+def list_events(session: Session, limit: int = 50) -> Iterable[models.Event]:
+    return session.query(models.Event).order_by(models.Event.created_at.desc()).limit(limit)
+
+
+def search_documents(session: Session, query: str) -> list[tuple[models.MediaObject, float]]:
+    from .vectorizer import cosine_similarity, embed_text
+
+    query_vector = embed_text(query)
+    results: list[tuple[models.MediaObject, float]] = []
+    vectors = session.query(models.DocumentVector).all()
+    for vector in vectors:
+        score = cosine_similarity(vector.vector, query_vector)
+        if score <= 0:
+            continue
+        results.append((vector.media_object, score))
+    results.sort(key=lambda item: item[1], reverse=True)
+    return results

--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -1,0 +1,71 @@
+"""Simple heuristics-based parser for purchase orders."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+
+class ParsedPurchase(BaseModel):
+    vendor_name: str
+    total_amount: float
+    currency: str = "USD"
+    due_date: Optional[datetime] = None
+    description: Optional[str] = None
+    asset_name: Optional[str] = None
+
+
+class PurchaseParser:
+    """Parse structured information from raw text invoices."""
+
+    def parse_text(self, content: str) -> tuple[ParsedPurchase, float]:
+        lines = [line.strip() for line in content.splitlines() if line.strip()]
+        vendor_name = self._extract_value(lines, ["vendor", "supplier"], default="Unknown Vendor")
+        total_amount = float(self._extract_value(lines, ["total", "amount"], default="0").replace("$", ""))
+        currency = "USD"
+        due_date_str = self._extract_value(lines, ["due", "pay by"], default="")
+        due_date = None
+        if due_date_str:
+            for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%d %b %Y"):
+                try:
+                    due_date = datetime.strptime(due_date_str, fmt)
+                    break
+                except ValueError:
+                    continue
+        description = self._extract_value(lines, ["description", "notes"], default=None)
+        asset_name = self._extract_value(lines, ["item", "product", "asset"], default=None)
+
+        parsed = ParsedPurchase(
+            vendor_name=vendor_name,
+            total_amount=total_amount,
+            currency=currency,
+            due_date=due_date,
+            description=description,
+            asset_name=asset_name,
+        )
+        confidence = 0.7 if total_amount > 0 else 0.3
+        return parsed, confidence
+
+    def _extract_value(self, lines: list[str], prefixes: list[str], default: Optional[str]) -> Optional[str]:
+        for line in lines:
+            lowered = line.lower()
+            for prefix in prefixes:
+                if lowered.startswith(prefix.lower()):
+                    parts = line.split(":", 1)
+                    if len(parts) == 2:
+                        return parts[1].strip()
+                    return line[len(prefix) :].strip()
+        return default
+
+
+def parser_event_payload(parsed: ParsedPurchase, confidence: float) -> Dict[str, Any]:
+    return {
+        "vendor_name": parsed.vendor_name,
+        "total_amount": parsed.total_amount,
+        "currency": parsed.currency,
+        "due_date": parsed.due_date.isoformat() if parsed.due_date else None,
+        "description": parsed.description,
+        "asset_name": parsed.asset_name,
+        "confidence": confidence,
+    }

--- a/app/services/vectorizer.py
+++ b/app/services/vectorizer.py
@@ -1,0 +1,44 @@
+"""Lightweight deterministic embedding generator."""
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Iterable, List
+
+import numpy as np
+
+VECTOR_DIM = 12
+
+
+def _tokenize(text: str) -> Iterable[str]:
+    for token in text.lower().split():
+        cleaned = "".join(ch for ch in token if ch.isalnum())
+        if cleaned:
+            yield cleaned
+
+
+def embed_text(text: str) -> List[float]:
+    """Create a deterministic embedding using hashing and sine transforms."""
+    if not text:
+        return [0.0] * VECTOR_DIM
+
+    vector = np.zeros(VECTOR_DIM, dtype=float)
+    for token in _tokenize(text):
+        token_hash = hashlib.sha256(token.encode("utf-8")).digest()
+        for i in range(VECTOR_DIM):
+            raw = token_hash[i] / 255.0
+            vector[i] += math.sin(raw * math.pi)
+
+    norm = np.linalg.norm(vector)
+    if norm == 0:
+        return vector.tolist()
+    return (vector / norm).tolist()
+
+
+def cosine_similarity(a: List[float], b: List[float]) -> float:
+    vec_a = np.array(a)
+    vec_b = np.array(b)
+    denom = np.linalg.norm(vec_a) * np.linalg.norm(vec_b)
+    if denom == 0:
+        return 0.0
+    return float(np.dot(vec_a, vec_b) / denom)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[project]
+name = "empire-os"
+version = "0.1.0"
+description = "First prototype of the Empire system backend"
+authors = [{name = "Empire Team"}]
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi~=0.103",
+    "uvicorn~=0.23",
+    "sqlalchemy~=2.0",
+    "pydantic~=1.10",
+    "python-multipart~=0.0.9",
+    "numpy~=1.26"
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest~=7.4",
+    "httpx~=0.25"
+]
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = ["app"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.main import create_app
+from app.database import Base, get_db
+import app.database as database
+from app.services import ingest as ingest_module
+
+
+@pytest.fixture()
+def client(tmp_path: Path) -> Generator[TestClient, None, None]:
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, expire_on_commit=False)
+    Base.metadata.create_all(bind=engine)
+
+    original_session_local = database.SessionLocal
+    database.SessionLocal = TestingSessionLocal
+
+    storage_path = tmp_path / "media"
+    storage_path.mkdir(parents=True, exist_ok=True)
+    ingest_module.MEDIA_ROOT = storage_path
+
+    app = create_app()
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with TestClient(app) as test_client:
+        yield test_client
+
+    app.dependency_overrides.clear()
+    database.SessionLocal = original_session_local

--- a/tests/test_empire.py
+++ b/tests/test_empire.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_purchase_ingest_and_agent_flow(client: TestClient) -> None:
+    content = """Vendor: Stellar Supplies\nTotal: 15000\nDue: 2023-09-01\nItem: Satellite Antenna\nDescription: Communication upgrade\n"""
+    response = client.post(
+        "/ingest/purchase",
+        data={"llc_name": "Orbital LLC"},
+        files={"file": ("invoice.txt", content, "text/plain")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+
+    purchase_order = payload["purchase_order"]
+    assert purchase_order["total_amount"] == 15000
+    assert purchase_order["vendor"]["name"] == "Stellar Supplies"
+
+    suggestions = payload["suggestions"]
+    assert any(s["suggestion_type"] == "create-repayment-plan" for s in suggestions)
+
+    events_response = client.get("/events")
+    assert events_response.status_code == 200
+    events = events_response.json()
+    event_types = {event["event_type"] for event in events}
+    assert {"ingest.received", "ingest.parsed", "purchase_order.created"}.issubset(event_types)
+
+    search_response = client.get("/search/documents", params={"query": "Satellite"})
+    assert search_response.status_code == 200
+    search_results = search_response.json()
+    assert search_results
+    assert search_results[0]["score"] > 0
+
+    overdue_content = """Vendor: Stellar Supplies\nTotal: 500\nDue: 2020-01-01\nDescription: Late invoice\n"""
+    response_overdue = client.post(
+        "/ingest/purchase",
+        data={"llc_name": "Orbital LLC"},
+        files={"file": ("invoice2.txt", overdue_content, "text/plain")},
+    )
+    assert response_overdue.status_code == 200
+    overdue_payload = response_overdue.json()
+    overdue_suggestions = overdue_payload["suggestions"]
+    flag = next((s for s in overdue_suggestions if s["suggestion_type"] == "flag-overdue"), None)
+    assert flag is not None
+
+    approve_response = client.post(f"/agents/suggestions/{flag['id']}/approve")
+    assert approve_response.status_code == 200
+    approval_payload = approve_response.json()
+    assert approval_payload["suggestion"]["approved"] is True
+    assert approval_payload["event"]["event_type"] == "agent_suggestion.approved"


### PR DESCRIPTION
## Summary
- implement a SQLAlchemy data model and initialization utilities for the Empire OS prototype
- add FastAPI endpoints with ingestion, search, and agent approval flows backed by parser, vectorizer, and finance agent services
- configure project packaging and provide pytest coverage for the end-to-end purchase ingestion and agent suggestion workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ce06f55560832da0bc9296f820628a